### PR TITLE
Support Elixir 1.12 and drop Elixir 1.8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,9 +19,9 @@ install_system_deps: &install_system_deps
         apk add fwup --repository=http://dl-cdn.alpinelinux.org/alpine/edge/community
 
 jobs:
-  build_elixir_1_11_otp_23:
+  build_elixir_1_12_otp_24:
     docker:
-      - image: hexpm/elixir:1.11.3-erlang-23.2.7-alpine-3.13.2
+      - image: hexpm/elixir:1.12.2-erlang-24.0.2-alpine-3.13.3
     <<: *defaults
     steps:
       - checkout
@@ -45,47 +45,44 @@ jobs:
             - _build
             - deps
 
-  build_elixir_1_10_otp_23:
+  build_elixir_1_11_otp_23:
     docker:
-      - image: hexpm/elixir:1.10.4-erlang-23.1.2-alpine-3.12.1
+      - image: hexpm/elixir:1.11.4-erlang-23.3.4-alpine-3.13.3
     <<: *defaults
     steps:
       - checkout
       - <<: *install_hex_rebar
       - <<: *install_system_deps
       - run: mix deps.get
-      - run: mix compile
+      - run: mix test
+
+  build_elixir_1_10_otp_23:
+    docker:
+      - image: hexpm/elixir:1.10.4-erlang-23.3.4-alpine-3.13.3
+    <<: *defaults
+    steps:
+      - checkout
+      - <<: *install_hex_rebar
+      - <<: *install_system_deps
+      - run: mix deps.get
       - run: mix test
 
   build_elixir_1_9_otp_22:
     docker:
-      - image: hexpm/elixir:1.9.4-erlang-22.3.4.9-alpine-3.12.0
+      - image: hexpm/elixir:1.9.4-erlang-22.3.4.18-alpine-3.13.3
     <<: *defaults
     steps:
       - checkout
       - <<: *install_hex_rebar
       - <<: *install_system_deps
       - run: mix deps.get
-      - run: mix compile
-      - run: mix test
-
-  build_elixir_1_8_otp_22:
-    docker:
-      - image: hexpm/elixir:1.8.2-erlang-22.3.4.9-alpine-3.12.0
-    <<: *defaults
-    steps:
-      - checkout
-      - <<: *install_hex_rebar
-      - <<: *install_system_deps
-      - run: mix deps.get
-      - run: mix compile
       - run: mix test
 
 workflows:
   version: 2
   build_test:
     jobs:
+      - build_elixir_1_12_otp_24
       - build_elixir_1_11_otp_23
       - build_elixir_1_10_otp_23
       - build_elixir_1_9_otp_22
-      - build_elixir_1_8_otp_22

--- a/mix.exs
+++ b/mix.exs
@@ -41,7 +41,7 @@ defmodule SSHSubsystemFwup.MixProject do
     [
       app: :ssh_subsystem_fwup,
       version: @version,
-      elixir: "~> 1.8",
+      elixir: "~> 1.9",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/mix.exs
+++ b/mix.exs
@@ -24,9 +24,7 @@ defmodule SSHSubsystemFwup.MixProject do
     Or manually update by changing #{script_path}:#{line_num} ¬
 
       #{IO.ANSI.red()}- #{String.trim(line)}
-      #{IO.ANSI.green()}+ cat "$FILENAME" | ssh -s $SSH_OPTIONS $DESTINATION fwup#{
-      IO.ANSI.default_color()
-    }
+      #{IO.ANSI.green()}+ cat "$FILENAME" | ssh -s $SSH_OPTIONS $DESTINATION fwup#{IO.ANSI.default_color()}
 
     NOTE: If you plan to do an over the air update of your system (as explained
     at https://github.com/nerves-project/nerves_ssh#upgrade-from-nervesfirmwaressh)


### PR DESCRIPTION
This is consistent with other Nerves projects. Elixir 1.9 is effectively
the minimum supported version with Nerves now.
