### PR TITLE
Support loading options from the application env

### DIFF
--- a/lib/ssh_subsystem_fwup.ex
+++ b/lib/ssh_subsystem_fwup.ex
@@ -81,7 +81,11 @@ defmodule SSHSubsystemFwup do
 
   @impl :ssh_client_channel
   def init(options) do
-    combined_options = Keyword.merge(default_options(), options)
+    # Combine the default options, any application environment options and finally subsystem options
+    combined_options =
+      default_options()
+      |> Keyword.merge(Application.get_all_env(:ssh_subsystem_fwup))
+      |> Keyword.merge(options)
 
     {:ok, %State{options: combined_options}}
   end


### PR DESCRIPTION
This makes it possible to have global defaults in the application
environment and then let them be overridden via the subsystem
configuration. This is more of a convenience than a necessity since it
is possible to override the subsystem specs with `:nerves_ssh`. However,
when you do that, you have to replicate what `:nerves_ssh` does with
configuring the devpath.

This adds docs to the README as well.
