### PR TITLE
Remove GenServer state struct

### DIFF
--- a/lib/ssh_subsystem_fwup.ex
+++ b/lib/ssh_subsystem_fwup.ex
@@ -70,20 +70,11 @@ defmodule SSHSubsystemFwup do
     {'fwup', {__MODULE__, options}}
   end
 
-  defmodule State do
-    @moduledoc false
-    defstruct state: :running_fwup,
-              id: nil,
-              cm: nil,
-              fwup: nil,
-              options: []
-  end
-
   @impl :ssh_client_channel
   def init(options) do
     combined_options = Keyword.merge(default_options(), options)
 
-    {:ok, %State{options: combined_options}}
+    {:ok, %{state: :running_fwup, id: nil, cm: nil, fwup: nil, options: combined_options}}
   end
 
   defp default_options() do


### PR DESCRIPTION
Convert the state struct to a normal map since we've been moving away
from using structs for GenServer state. The reasons are that they don't
help as much as initially thought (over regular maps) with catching
mistakes and it's one less .beam file to load at run time.
