### PR TITLE
Add Dependabot automerge

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,15 @@ version: 2.1
 latest: &latest
   pattern: "^1.15.6-erlang-26.*$"
 
+tags: &tags
+  [
+    1.15.6-erlang-26.1.1-alpine-3.18.2,
+    1.14.5-erlang-25.3.2.6-alpine-3.18.2,
+    1.13.4-erlang-25.3.2.6-alpine-3.18.2,
+    1.12.3-erlang-24.3.4.13-alpine-3.18.2,
+    1.11.4-erlang-24.3.4.13-alpine-3.18.2
+  ]
+
 jobs:
   build-test:
     parameters:
@@ -44,6 +53,24 @@ jobs:
             - _build
             - deps
 
+  automerge:
+    docker:
+        - image: alpine:3.18.4
+    steps:
+      - run:
+          name: Install GitHub CLI
+          command: apk add --no-cache build-base github-cli
+      - run:
+          name: Attempt PR automerge
+          command: |
+            author=$(gh pr view "${CIRCLE_PULL_REQUEST}" --json author --jq '.author.login' || true)
+
+            if [ "$author" = "app/dependabot" ]; then
+              gh pr merge "${CIRCLE_PULL_REQUEST}" --auto --rebase || echo "Failed trying to set automerge"
+            else
+              echo "Not a dependabot PR, skipping automerge"
+            fi
+
 workflows:
   checks:
     jobs:
@@ -51,10 +78,11 @@ workflows:
           name: << matrix.tag >>
           matrix:
             parameters:
-              tag: [
-                1.15.6-erlang-26.1.1-alpine-3.18.2,
-                1.14.5-erlang-25.3.2.6-alpine-3.18.2,
-                1.13.4-erlang-25.3.2.6-alpine-3.18.2,
-                1.12.3-erlang-24.3.4.13-alpine-3.18.2,
-                1.11.4-erlang-24.3.4.13-alpine-3.18.2
-              ]
+              tag: *tags
+
+      - automerge:
+          requires: *tags
+          context: org-global
+          filters:
+            branches:
+              only: /^dependabot.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,11 +1,11 @@
 version: 2.1
 
 latest: &latest
-  pattern: "^1.15.6-erlang-26.*$"
+  pattern: "^1.15.7-erlang-26.*$"
 
 tags: &tags
   [
-    1.15.6-erlang-26.1.1-alpine-3.18.2,
+    1.15.7-erlang-26.1.2-alpine-3.18.4,
     1.14.5-erlang-25.3.2.6-alpine-3.18.2,
     1.13.4-erlang-25.3.2.6-alpine-3.18.2,
     1.12.3-erlang-24.3.4.13-alpine-3.18.2,


### PR DESCRIPTION
Adds an extra job that will run only on dependabot PR's, require all previous jobs to be successful, and require the PR was created by dependabot. If all conditions are met, it will automatically merge the dependabot PR