### PR TITLE
mix/tasks/upload: Clear LD_LIBRARY_PATH when running ssh

### DIFF
--- a/lib/mix/tasks/upload.ex
+++ b/lib/mix/tasks/upload.ex
@@ -87,6 +87,10 @@ defmodule Mix.Tasks.Upload do
          "-s",
          ip,
          "fwup"
+       ]},
+      {:env,
+       [
+         {~c"LD_LIBRARY_PATH", false}
        ]}
     ]
 


### PR DESCRIPTION
The host system's ssh binary is being used, but LD_LIBRARY_PATH may be set to a nerves system's artifact host/lib directory. This can cause ssh to fail unexpectedly with some thing like this:

```
OpenSSL version mismatch. Built against 30000020, you have 30200010
** (Mix) Unexpected exit from ssh (:epipe)
```