### PR TITLE
Delay on successful completion to allow graceful close

### DIFF
--- a/lib/ssh_subsystem_fwup.ex
+++ b/lib/ssh_subsystem_fwup.ex
@@ -195,8 +195,15 @@ defmodule SSHSubsystemFwup do
   defp run_callback(0 = _rc, {m, f, args}) do
     # Let others know that fwup was successful. The usual operation
     # here is to reboot. Run the callback in its own process so that
-    # any issues with it don't affect processing here.
-    _ = spawn(m, f, args)
+    # any issues with it don't affect processing here. A short delay
+    # gives the SSH connection time to close cleanly before the
+    # callback (e.g., reboot) tears down the system.
+    _ =
+      spawn(fn ->
+        Process.sleep(500)
+        apply(m, f, args)
+      end)
+
     :ok
   end
 

--- a/test/ssh_subsystem_fwup_test.exs
+++ b/test/ssh_subsystem_fwup_test.exs
@@ -100,7 +100,7 @@ defmodule SSHSubsystemFwupTest do
     end)
 
     # Check that the success function was called
-    assert_receive :success
+    assert_receive :success, 1000, 1000
 
     # Check that the update was applied
     # First 512 bytes is "Hello, world!"
@@ -132,7 +132,7 @@ defmodule SSHSubsystemFwupTest do
     end)
 
     # Check that the success function was called
-    assert_receive :success
+    assert_receive :success, 1000
 
     # Check that the update was applied
     # The first 512 bytes should be the Hello world
@@ -206,7 +206,7 @@ defmodule SSHSubsystemFwupTest do
     end)
 
     # Check that the success function was called
-    assert_receive :success
+    assert_receive :success, 1000
 
     # Check that the update was applied
     assert match?(<<"Hello, world!", _::binary>>, File.read!(options[:devpath]))
@@ -250,7 +250,7 @@ defmodule SSHSubsystemFwupTest do
     end)
 
     # Check that the success function was called
-    assert_receive :success
+    assert_receive :success, 1000
 
     # Check that the update was applied
     assert match?(<<"Hello, world!", _::binary>>, File.read!(options[:devpath]))
@@ -289,7 +289,7 @@ defmodule SSHSubsystemFwupTest do
     end)
 
     # Check that the success function was called
-    assert_receive :success
+    assert_receive :success, 1000
 
     # Check that the update was applied
     assert match?(<<"Hello, world!", _::binary>>, File.read!(options[:devpath]))


### PR DESCRIPTION
This addresses the problem where the reboot happens before the SSH
connection closes normally.

```
fwup: Upgrading partition B
100% [====================================] 71.41 MB in / 83.54 MB out
Success!
Elapsed time: 1 min 02 s
Received disconnect from 192.168.1.63 port 22:11: Terminated (shutdown) by supervisor
Disconnected from 192.168.1.63 port 22
** (Mix) Failed to upgrade the device.
```
