### PR TITLE
Update HexDoc URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 # SSHSubsystemFwup
 
 [![Hex version](https://img.shields.io/hexpm/v/ssh_subsystem_fwup.svg "Hex version")](https://hex.pm/packages/ssh_subsystem_fwup)
-[![API docs](https://img.shields.io/hexpm/v/ssh_subsystem_fwup.svg?label=hexdocs "API docs")](https://hexdocs.pm/ssh_subsystem_fwup/SSHSubsystemFwup.html)
+[![API docs](https://img.shields.io/hexpm/v/ssh_subsystem_fwup.svg?label=hexdocs "API docs")](https://ssh-subsystem-fwup.hexdocs.pm/SSHSubsystemFwup.html)
 [![CircleCI](https://dl.circleci.com/status-badge/img/gh/nerves-project/ssh_subsystem_fwup/tree/main.svg?style=svg)](https://dl.circleci.com/status-badge/redirect/gh/nerves-project/ssh_subsystem_fwup/tree/main)
 [![REUSE status](https://api.reuse.software/badge/github.com/nerves-project/ssh_subsystem_fwup)](https://api.reuse.software/info/github.com/nerves-project/ssh_subsystem_fwup)
 


### PR DESCRIPTION
Migrates HexDocs URLs to the 2026 format using hex_url_migrator.

<details>
<summary>⚠️ URL verification warnings from <code>hex_url_migrator --verify</code></summary>

```
❌ Verification failed for https://ssh-subsystem-fwup.hexdocs.pm/SSHSubsystemFwup.html): Status 404
⚠️ Verification finished: 0 success, 1 failure(s).
```

_Reported by the migrator's verifier. Note that `301`s are typically redirects (the target exists) and a trailing `)` is a markdown-link parsing artifact. Please review before merging._
</details>