### PR TITLE
Fix new OTP 29.0.6 ssh error on upload

### DIFF
--- a/lib/mix/tasks/firmware.gen.script.ex
+++ b/lib/mix/tasks/firmware.gen.script.ex
@@ -111,7 +111,7 @@ defmodule Mix.Tasks.Firmware.Gen.Script do
   echo
   echo "Uploading to $DESTINATION..."
 
-  cat "$FILENAME" | ssh -s $SSH_OPTIONS $DESTINATION fwup
+  cat "$FILENAME" | env -i ssh -s $SSH_OPTIONS $DESTINATION fwup
   """
 
   @spec run(keyword()) :: :ok

--- a/lib/mix/tasks/upload.ex
+++ b/lib/mix/tasks/upload.ex
@@ -83,11 +83,19 @@ defmodule Mix.Tasks.Upload do
 
     ssh_cmd = build_ssh_command(firmware_path, ip, port, password)
 
-    # LD_LIBRARY_PATH is unset to avoid errors with host ssl (see commit 9b1df471)
+    # Run ssh with a cleared environment to avoid the following:
+    # 1. LD_LIBRARY_PATH errors with host ssl (see commit 9b1df471)
+    # 2. OTP 29.0.6 change at https://github.com/erlang/otp/pull/11437 that
+    #    prevents the fwup subsystem to be requested if OS vars are set.
+    clear_env =
+      System.get_env()
+      |> Enum.reject(fn {k, _v} -> k == "PATH" end)
+      |> Enum.map(fn {k, _} -> {k, nil} end)
+
     {_, status} =
       InteractiveCmd.shell(
         ssh_cmd,
-        env: [{"LD_LIBRARY_PATH", false}]
+        env: clear_env
       )
 
     cond do


### PR DESCRIPTION
This fixes the following error when running `mix upload` with OTP
29.0.6:

```
subsystem request failed on channel 0
cat: stdout: Broken pipe
```

The fix is to clear out the OS environment so that ssh doesn't make a
channel request to forward OS environment variables. Just making that
request now results in a refusal to open a subsequent subsystem like the
one for the upload.

Thanks to @Hermanverschooten for reporting this and identifying the
cause.